### PR TITLE
Add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# CMS
+
+A full-stack course management system.
+
+## Overview
+- **Backend** – Java 17 with Spring Boot 3.5, Spring Data JDBC and an SQLite database.
+- **Frontend** – Vue 3 + Vite single-page application using Pinia for state and Bootstrap for styling.
+
+## Running the project
+
+### Backend
+```bash
+./gradlew bootRun
+```
+The service starts on port **8100** and initializes `schema.sql` on first run.
+
+### Frontend
+```bash
+cd src/frontend
+npm install
+npm run dev
+```
+Vite serves the SPA at `http://localhost:5173` by default.
+
+## Project layout
+```
+cms/
+├── build.gradle
+├── src/
+│   ├── main/
+│   │   ├── java/backend/      # Spring Boot source
+│   │   └── resources/         # application.properties, schema.sql, static HTML
+│   └── frontend/              # Vue 3 app
+└── ...
+```
+
+See the `docs/` directory for architectural notes and API details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This directory provides deeper technical information:
+
+| File | Purpose |
+| ---- | ------- |
+| `architecture.md` | Codebase structure and main components. |
+| `api.md` | REST API endpoints and data models. |
+| `frontend.md` | Frontend architecture and utilities. |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,50 @@
+# REST API
+
+Base URL: `/api`
+
+## Courses
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/courses` | List all courses |
+| GET | `/courses/active` | List courses not marked `closed` |
+| GET | `/courses/{id}` | Fetch a single course by ID |
+| POST | `/courses` | Create a course from request body |
+| PUT | `/courses/{id}` | Partially update a course; only provided fields are applied |
+
+### Course model
+```json
+{
+  "id": number,
+  "title": string,
+  "name": string,
+  "priority": "low" | "medium" | "high",
+  "term": "fall" | "winter" | "spring" | "summer",
+  "year": number,
+  "status": "active" | "closed" | "upcoming"
+}
+```
+
+## Tasks
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/tasks` | List tasks joined with their courses, ordered by due date |
+| GET | `/tasks/active` | Same as above but filters out tasks linked to closed courses |
+| POST | `/tasks` | Create a task; response includes joined course info |
+| PUT | `/tasks/{id}` | Partially update a task by ID |
+| DELETE | `/tasks/{id}` | Remove a task by ID |
+
+### Task model
+```json
+{
+  "id": number,
+  "name": string,
+  "courseId": number,
+  "due": "YYYY-MM-DDTHH:mm",
+  "priority": "low" | "medium" | "high",
+  "status": "not_started" | "in_progress" | "completed"
+}
+```
+
+Task endpoints often return the `TaskWithCourse` projection, which adds `courseTitle`, `courseName`, `coursePriority`, `courseTerm` and `courseYear` from the joined course record.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,24 @@
+# Architecture
+
+## Backend (Spring Boot)
+
+`src/main/java/backend/`
+
+- **config/** – JDBC converters and configuration mapping enums and `LocalDateTime` so SQLite can persist them as text.
+- **controllers/** – REST controllers exposing `/api/courses` and `/api/tasks` endpoints.
+- **course/** – `Course` entity and `CourseRepository` for CRUD operations.
+- **task/** – `Task`, `TaskWithCourse` DTO and `TaskRepository` combining tasks with their courses.
+- **utils/** – Enum types used across the domain (`Priority`, `TaskStatus`, `CourseStatus`, `Term`).
+- **BackendApplication.java** – Spring Boot entry point.
+
+`src/main/resources/` holds configuration and database schema. `schema.sql` defines tables `course` and `task` with foreign key constraints.
+
+## Frontend (Vue 3 + Vite)
+
+`src/frontend/`
+
+- **src/router/** – Vue Router configuration mapping URLs to dashboard, course and task views.
+- **src/views/** – Page-level components (`Dashboard.vue`, `Courses.vue`, `Tasks.vue`, etc.).
+- **src/components/** – Reusable UI elements, modals, cards and tables.
+- **src/stores/** – Pinia stores for application state.
+- **src/utils/** – Shared helpers such as `fetchData` for HTTP calls and string utilities.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,24 @@
+# Frontend Overview
+
+The SPA is built with Vue 3 and Vite and uses Pinia for state management.
+
+## Routing
+
+`src/router/index.ts` configures five routes:
+
+- `/` → `Dashboard.vue`
+- `/about` → `AboutView.vue`
+- `/courses` and `/course/:id` → `Courses.vue`
+- `/tasks` → `Tasks.vue`
+
+## Utilities
+
+`src/utils/fetchData.ts` wraps the Fetch API with JSON handling and error propagation. `functions.ts` supplies helpers like `toTitle` for transforming enum strings into human-readable labels.
+
+## State
+
+Pinia stores (e.g., `stores/counter.ts`) demonstrate reactive state modules.
+
+## Components & Views
+
+Views such as `Courses.vue` and `Tasks.vue` assemble reusable components from `src/components/` (cards, tables, modals) to present and manipulate data retrieved from the backend.


### PR DESCRIPTION
## Summary
- Add top-level README with project overview and run instructions.
- Document backend and frontend architecture, REST API, and SPA details under a new `docs/` directory.

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c490c4695c832785c2ef04aab0a192